### PR TITLE
Removed DeduplicateBootOrder quirk with OC 0.6.5+

### DIFF
--- a/11.0/OC/config.plist
+++ b/11.0/OC/config.plist
@@ -1026,8 +1026,6 @@
 		</dict>
 		<key>Quirks</key>
 		<dict>
-			<key>DeduplicateBootOrder</key>
-			<false/>
 			<key>ExitBootServicesDelay</key>
 			<integer>0</integer>
 			<key>IgnoreInvalidFlexRatio</key>


### PR DESCRIPTION
Hi @wmchris ,
With OC v0.6.5 we have many changelogs especially, 
> Removed no longer required `DeduplicateBootOrder` quirk ([0.6.5 Release notes](https://github.com/acidanthera/OpenCorePkg/releases/tag/0.6.5))

Maybe when upgrade to OC 0.6.6, you're missed this.
So, I think we should remove it from `config.plist` (Of course it still can boot with keep `DeduplicateBootOrder` quirk, but OC will show some message when start like the attach picture.
This PR solved that and just removed it without edit anything else part.

![149326868_466755174504246_1030029241151617632_n](https://user-images.githubusercontent.com/33023931/109385809-105bbe00-7929-11eb-8dc4-5167bdba2140.png)
