### PR TITLE
Fix built-in HDMI output

### DIFF
--- a/12.0/OC/config.plist
+++ b/12.0/OC/config.plist
@@ -359,6 +359,16 @@
 				<data>AQAAAA==</data>
 				<key>force-online</key>
 				<data>AQAAAA==</data>
+				<key>framebuffer-con0-enable</key>
+				<data>AQAAAA==</data>
+				<key>framebuffer-con0-pipe</key>
+				<data>EgAAAA==</data>
+				<key>framebuffer-con1-enable</key>
+				<data>AQAAAA==</data>
+				<key>framebuffer-con1-pipe</key>
+				<data>EgAAAA==</data>
+				<key>framebuffer-con1-type</key>
+				<data>AAgAAA==</data>
 				<key>framebuffer-patch-enable</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-unifiedmem</key>


### PR DESCRIPTION
HDMI-Audio is also working and usb-c to hdmi functionality is not impacted.

Not sure if thats a "minimal" patch but it works on opencore 0.7.6 with the latest available kexts.